### PR TITLE
fixes to template libraries

### DIFF
--- a/yaml/org.storymaker.app/t_audio/t_audio/t_audio_library.yaml
+++ b/yaml/org.storymaker.app/t_audio/t_audio/t_audio_library.yaml
@@ -10,7 +10,28 @@
         t_audio_highlights: t_audio_highlights.json
         t_audio_report_event: t_audio_report_event.json
         t_audio_report_issue: t_audio_report_issue.json
-
+    dependencies:
+        -
+          dependencyId: t_audio_day_in_the_life
+          dependencyFile: t_audio_day_in_the_life.json
+        -
+          dependencyId: t_audio_discussion_question_1
+          dependencyFile: t_audio_discussion_question_1.json
+        -
+          dependencyId: t_audio_discussion_question_2
+          dependencyFile: t_audio_discussion_question_2.json
+        -
+          dependencyId: t_audio_discussion_question_3
+          dependencyFile: t_audio_discussion_question_3.json
+        -
+          dependencyId: t_audio_highlights
+          dependencyFile: t_audio_highlights.json
+        -
+          dependencyId: t_audio_report_event
+          dependencyFile: t_audio_report_event.json
+        -
+          dependencyId: t_audio_report_issue
+          dependencyFile: t_audio_report_issue.json
     cards:
         -
             type: TipCollectionHeadlessCard

--- a/yaml/org.storymaker.app/t_news/t_news/t_news_library.yaml
+++ b/yaml/org.storymaker.app/t_news/t_news/t_news_library.yaml
@@ -11,7 +11,31 @@
         t_news_issue_video: t_news_issue_video.json
         t_news_profile_audio: t_news_profile_audio.json
         t_news_profile_video: t_news_profile_video.json
-
+    dependencies:
+        -
+        dependencyId: t_news_breaking_audio
+        dependencyFile: t_news_breaking_audio.json
+        -
+        dependencyId: t_news_breaking_video
+        dependencyFile: t_news_breaking_video.json
+        -
+        dependencyId: t_news_event_audio
+        dependencyFile: t_news_event_audio.json
+        -
+        dependencyId: t_news_event_video
+        dependencyFile: t_news_event_video.json
+        -
+        dependencyId: t_news_issue_audio
+        dependencyFile: t_news_issue_audio.json
+        -
+        dependencyId: t_news_issue_video
+        dependencyFile: t_news_issue_video.json
+        -
+        dependencyId: dependencyId: t_news_profile_audio
+        dependencyFile: t_news_profile_audio.json
+        -
+        dependencyId: t_news_profile_video
+        dependencyFile: t_news_profile_video.json
     cards:
         -
             type: TipCollectionHeadlessCard
@@ -208,7 +232,7 @@
                     id: video
                     text: Video
                     filters_or:
-                        - t_news_library::quiz_card_topic::choice::t_breaking_news
+                        - t_news_library::quiz_card_topic::choice::t_news_breaking
                         - t_news_library::quiz_card_topic::choice::t_news_event
                         - t_news_library::quiz_card_topic::choice::t_news_issue
                         - t_news_library::quiz_card_topic::choice::t_news_profile

--- a/yaml/org.storymaker.app/t_photo/t_photo/t_photo_library.yaml
+++ b/yaml/org.storymaker.app/t_photo/t_photo/t_photo_library.yaml
@@ -9,6 +9,25 @@
         t_photo_series_action: t_photo_series_action.json
         t_photo_series_signature: t_photo_series_signature.json
         t_photo_process: t_photo_process.json
+    dependencies:
+        -
+        dependencyId: t_photo_highlights
+        dependencyFile: t_photo_highlights.json
+        -
+        dependencyId: t_photo_series_character
+        dependencyFile: t_photo_series_character.json
+        -
+        dependencyId: t_photo_series_place
+        dependencyFile: t_photo_series_place.json
+        -
+        dependencyId: t_photo_series_action
+        dependencyFile: t_photo_series_action.json
+        -
+        dependencyId: t_photo_series_signature
+        dependencyFile: t_photo_series_signature.json
+        -
+        dependencyId: t_photo_process
+        dependencyFile: t_photo_process.json
 
     cards:
         -
@@ -90,7 +109,7 @@
 
                 -
                     id: t_photo_series_signature
-                    text: Objects
+                    text: A Series of Objects
 
 		    -
             type: MilestoneCard
@@ -103,7 +122,7 @@
             type: TextCard
             text: 'A photo essay is a story told over any number of related photos. These templates will guide you to get all the photos you need to tell a variety of stories.'
             references:
-              - video_library::ms_moreinfo::value::true
+              - t_photo_library::ms_moreinfo::value::true
 
         -
             type: HookLoaderHeadlessCard

--- a/yaml/org.storymaker.app/t_process/t_process/t_process_library.yaml
+++ b/yaml/org.storymaker.app/t_process/t_process/t_process_library.yaml
@@ -9,7 +9,25 @@
         t_process_profile_audio: t_process_profile_audio.json
         t_process_profile_photo: t_process_profile_photo.json
         t_process_profile_video: t_process_profile_video.json
-
+    dependencies:
+        -
+        dependencyId: t_process_event_audio
+        dependencyFile: t_process_event_audio.json
+        -
+        dependencyId: t_process_event_photo
+        dependencyFile: t_process_event_photo.json
+        -
+        dependencyId: t_process_event_video
+        dependencyFile: t_process_event_video.json
+        -
+        dependencyId: t_process_profile_audio
+        dependencyFile: t_process_profile_audio.json
+        -
+        dependencyId: t_process_profile_photo
+        dependencyFile: t_process_profile_photo.json
+        -
+        dependencyId: t_process_profile_video
+        dependencyFile: t_process_profile_video.json
     cards:
         -
             type: TipCollectionHeadlessCard

--- a/yaml/org.storymaker.app/t_video/t_video/t_video_library.yaml
+++ b/yaml/org.storymaker.app/t_video/t_video/t_video_library.yaml
@@ -1,5 +1,5 @@
 ---
-    id: video_stories
+    id: t_video_library
     title: Make a Video Story
     classPackage: scal.io.liger.model
     storyPathTemplateFiles:
@@ -10,7 +10,28 @@
         t_video_highlights: t_video_highlights.json
         t_video_report_event: t_video_report_event.json
         t_video_report_issue: t_video_report_issue.json
-
+    dependencies:
+        -
+        dependencyId: t_video_day_in_the_life
+        dependencyFile: t_video_day_in_the_life.json
+        -
+        dependencyId: t_video_discussion_question_1
+        dependencyFile: t_video_discussion_question_1.json
+        -
+        dependencyId: t_video_discussion_question_2
+        dependencyFile: t_video_discussion_question_2.json
+        -
+        dependencyId: t_video_discussion_question_3
+        dependencyFile: t_video_discussion_question_3.json
+        -
+        dependencyId: t_video_highlights
+        dependencyFile: t_video_highlights.json
+        -
+        dependencyId: t_video_report_event
+        dependencyFile: t_video_report_event.json
+        -
+        dependencyId: t_video_report_issue
+        dependencyFile: t_video_report_issue.json
     cards:
         -
             type: TipCollectionHeadlessCard
@@ -194,11 +215,11 @@
             type: TextCard
             text: 'Making a great video story involves a variety of clips. These templates will guide you to get all the clips you need to tell a variety of stories.'
             references:
-              - video_stories::ms_moreinfo::value::true
+              - t_video_library::ms_moreinfo::value::true
 
         -
             type: HookLoaderHeadlessCard
             id: hook_loader_card
             action: LOAD
             references:
-                - video_stories::quiz_card_topic::choice
+                - t_video_library::quiz_card_topic::choice


### PR DESCRIPTION
This fix involved the addition of dependencies, as well as fixing some
incorrectly named paths, which meant the user could not choose a path,
or caused the “more info” button to not work.

I still need to commit a “more info” milestone card for t_process. I
can do that this evening.
